### PR TITLE
Issue: Folders Invisible in frontend in Mac OS

### DIFF
--- a/Backend/controllers/Folder-Files/folder.controller.js
+++ b/Backend/controllers/Folder-Files/folder.controller.js
@@ -294,7 +294,7 @@ const getFolderStructure = async (req, res) => {
       // Get all subfolders of the target folder
       const subFolders = await FolderModel.find({ 
           owner: userId, 
-          path: { $regex: `^${escapeRegExp(targetFolder.path)}(\\\\|$)` }
+          path: { $regex: `^${escapeRegExp(targetFolder.path)}([\\\\/]|$)` }
       }).lean();
 
       // Get all files in the target folder


### PR DESCRIPTION
Fixes #4 
- Fixes folders not visible in mac os by changing the path regex to ensure that the regular expression matches both backslashes and forward slashes, making it compatible with both Windows and macOS file systems.